### PR TITLE
trim address/hash in search bar

### DIFF
--- a/src/app/navigation/search-bar/search-bar.component.ts
+++ b/src/app/navigation/search-bar/search-bar.component.ts
@@ -120,7 +120,7 @@ export class SearchBarComponent implements OnInit, AfterViewInit, AfterViewCheck
 
     /** Call this method to manually search based off of current input field value. */
     searchCurrentValue(controlKey: boolean, e?: KeyboardEvent): void {
-        const value = this.appbarSearchText || '';
+        const value = this.appbarSearchText ? this.appbarSearchText.trim() : '';
 
         // Handle Empty Case
         if (!value) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49297268/229671758-6b37ebec-a02b-4a65-871a-0bb6fdf33cbc.png)

Search doesn't work if space is in front of or behind address/hash. I think this is easy fix, let me know if I did anything wrong.
Thank you!